### PR TITLE
build: fix TypeScript strict mode errors

### DIFF
--- a/lib/components/Brand/BrandExpansion.vue
+++ b/lib/components/Brand/BrandExpansion.vue
@@ -166,12 +166,12 @@ const breakpoints = useBreakpoints({
   [BrandMode.Long]: 1047.01
 })
 const baseWidth = computed((): number => {
-  const widths = {
+  const widths: Record<BrandMode, number> = {
     [BrandMode.Short]: 401.256,
     [BrandMode.Medium]: 901.24,
     [BrandMode.Long]: 1047.01
   }
-  return widths[props.mode]
+  return widths[props.mode as BrandMode]
 })
 
 const sizeAsNumber = computed((): number => {

--- a/lib/components/Form/FormAdvancedLink/FormAdvancedLink.vue
+++ b/lib/components/Form/FormAdvancedLink/FormAdvancedLink.vue
@@ -91,11 +91,11 @@ const advancedLinkFormId = uniqueId('advanced-link-form-')
 
 const { t } = useI18n()
 const formClasses = computed(() => {
-  const propsToCheck = ['card', 'pills', 'small', 'vertical']
+  const propsToCheck = ['card', 'pills', 'small', 'vertical'] as const
   return propsToCheck.reduce((classes, prop) => {
     classes[`advanced-link-form--${prop}`] = props[prop]
     return classes
-  }, {})
+  }, {} as Record<string, boolean>)
 })
 
 // default tabs order
@@ -123,7 +123,7 @@ const activeForm = computed(() => {
 )
 
 function onUpdate(event: string | undefined): void {
-  const id = tabs.value.findIndex(elem => elem.id === event)
+  const id = tabs.value.findIndex((elem: { id: string }) => elem.id === event)
   index.value = id < 0 ? 0 : id
 }
 

--- a/lib/components/Form/FormAdvancedLink/FormAdvancedLinkTab.vue
+++ b/lib/components/Form/FormAdvancedLink/FormAdvancedLinkTab.vue
@@ -69,7 +69,6 @@ function select() {
 const selectInput = async (target: Readonly<ShallowRef<HTMLInputElement | null>>) => {
   // wait for the copy to finish to select text
   await nextTick()
-  // @ts-expect-error element does exist on target.value but IDE says it doesn't :'(
   target.value?.element.select()
 }
 

--- a/lib/components/Form/FormControl/FormControlDigits.vue
+++ b/lib/components/Form/FormControl/FormControlDigits.vue
@@ -87,15 +87,15 @@ function focusToPreviousWhenEmpty(d: number) {
 
 watch(
   () => values,
-  (values) => {
+  (valuesRef: typeof values) => {
     // Copy and remove values that are not numbers
-    const formattedValues = values.value.map(value =>
+    const formattedValues = valuesRef.value.map((value: string) =>
       String(value).replace(/\D/g, '')
     )
     // Iterate over the values to be sure
     // they are not exceeding 10 and should
     // be spread to the next inputs
-    formattedValues.forEach((value, d) => {
+    formattedValues.forEach((value: string, d: number) => {
       // The value must be spread to the next input only
       // if it's higher than 9 (more than one digit)
       if (value !== null && Number(value) > 9) {
@@ -110,8 +110,8 @@ watch(
     })
     // We update the values data attribute only if they changed
     // to avoid an infinite update cycle
-    if (JSON.stringify(values.value) !== JSON.stringify(formattedValues)) {
-      values.value = formattedValues.slice(0, props.length)
+    if (JSON.stringify(valuesRef.value) !== JSON.stringify(formattedValues)) {
+      valuesRef.value = formattedValues.slice(0, props.length)
     }
     focusToNextInput()
   },

--- a/lib/components/Form/FormControl/FormControlRange.vue
+++ b/lib/components/Form/FormControl/FormControlRange.vue
@@ -264,7 +264,7 @@ function valueWithUnit(value: number | string): string {
   return typeof value === 'number' ? `${value}px` : `${value}`
 }
 
-watch(() => props.range, (newRange) => {
+watch(() => props.range, (newRange: [number, number]) => {
   start.value = newRange[0] ?? 0
   end.value = newRange[1] ?? 0
 })

--- a/lib/components/Form/FormControl/FormControlSelectableDropdown.vue
+++ b/lib/components/Form/FormControl/FormControlSelectableDropdown.vue
@@ -169,14 +169,14 @@ const keysMap = computed((): Record<string, Function> => {
 
 watch(toRef(props, 'hide'), toggleKeys)
 
-watch(modelValue, (itemOrItems) => {
+watch(modelValue, (itemOrItems: unknown) => {
   const items = castArray(itemOrItems)
   if (!isEqual(activeItems.value, items)) {
     activateItemOrItems(itemOrItems)
   }
 }, { deep: true, immediate: false })
 
-watch(activeItems, (itemOrItems) => {
+watch(activeItems, (itemOrItems: unknown[]) => {
   /**
    * Fired when the selected value changes. It will pass a canonical value
    * or an array of values if the property `multiple` is set to true.

--- a/lib/components/Form/FormDonate.vue
+++ b/lib/components/Form/FormDonate.vue
@@ -58,11 +58,9 @@ const labelForChange = ref<LabelForChange>({
 })
 
 const suggestedAmount = ref<SuggestedDonation>(
-  // @ts-expect-error retrieves a map of messages from the i18n json
   messages.value[locale.value]['donate-form']['suggesteddonation']
 )
 const listBenefits = ref<string[]>(
-  // @ts-expect-error retrieves a list of messages from the i18n json
   messages.value[locale.value]['donate-form']['benefits']['list']
 )
 
@@ -123,7 +121,7 @@ watch(installmentPeriod, () => {
 
 watch(
   () => amount.value,
-  (v) => {
+  (v: number) => {
     level.value = changeThe.value
 
     // Set manual amount

--- a/lib/components/HapticCopy/HapticCopy.vue
+++ b/lib/components/HapticCopy/HapticCopy.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Timeout } from 'node:timers'
 import { BButton, BTooltip, PopoverPlacement, ButtonVariant } from 'bootstrap-vue-next'
 import noop from 'lodash/noop'
 import uniqueId from 'lodash/uniqueId'
@@ -94,7 +93,7 @@ const { t, te } = useI18n()
 const tooltip = ref<ComponentPublicInstance | null>(null)
 const el = ref<ComponentPublicInstance<HTMLElement> | null>(null)
 const tooltipContent = ref<string>('')
-const tooltipTimeout = ref<Timeout | undefined>(undefined)
+const tooltipTimeout = ref<ReturnType<typeof setTimeout> | undefined>(undefined)
 const showClipboardTooltip = ref(false)
 const buttonId = computed(() => uniqueId('haptic-copy-'))
 const buttonBinding = computed(() => {

--- a/lib/components/ImageMode/ImageMode.vue
+++ b/lib/components/ImageMode/ImageMode.vue
@@ -37,15 +37,15 @@ const classList = computed(() => {
 })
 
 const sources = computed(() => {
-  return imageModeSources.value.map(source => source.dataset)
+  return imageModeSources.value.map((source: HTMLElement) => source.dataset)
 })
 
 const source = computed(() => {
-  return sources.value.find(source => source.colorMode === colorMode.value)
+  return sources.value.find((source: DOMStringMap) => source.colorMode === colorMode.value)
 })
 
 const defaultSource = computed(() => {
-  return sources.value.find(source => source.colorMode === props.defaultColorMode || !source.colorMode)
+  return sources.value.find((source: DOMStringMap) => source.colorMode === props.defaultColorMode || !source.colorMode)
 })
 
 const src = computed(() => {

--- a/lib/components/Legend/LegendOrdinal.vue
+++ b/lib/components/Legend/LegendOrdinal.vue
@@ -60,7 +60,7 @@ const classList = computed(() => {
 })
 
 function itemClassList(d: Datum) {
-  const id = d[props.categoryObjectsPath]
+  const id = d[props.categoryObjectsPath as Category] as string | number | undefined
   return {
     [`ordinal-legend__item--identifier-${kebabCase(d.label)}`]: true,
     'ordinal-legend__item--highlighted': id === props.highlight,

--- a/lib/components/Legend/LegendScale.vue
+++ b/lib/components/Legend/LegendScale.vue
@@ -94,7 +94,7 @@ const hasCursor = computed((): boolean => {
 
 const colorScaleFunction = computed((): ColorScaleFn => {
   if (isString(props.colorScale)) {
-    const fn: () => any = scaleFunctions[props.colorScale]
+    const fn: () => any = (scaleFunctions as unknown as Record<string, () => any>)[props.colorScale]
     return fn()
       .domain([props.min, props.max])
       .range([props.colorScaleStart, props.colorScaleEnd])

--- a/lib/components/Pagination/PaginationTiny.vue
+++ b/lib/components/Pagination/PaginationTiny.vue
@@ -168,7 +168,7 @@ import type { ButtonVariant, Size } from 'bootstrap-vue-next'
 import { SIZE } from '@/enums'
 import vEllipsisTooltip from '@/directives/EllipsisTooltip'
 import PhosphorIcon from '@/components/PhosphorIcon/PhosphorIcon.vue'
-import { PhCaretDoubleLeft, PhCaretRight } from '@phosphor-icons/vue'
+import { PhCaretDoubleLeft, PhCaretDoubleRight, PhCaretLeft, PhCaretRight } from '@phosphor-icons/vue'
 import type { IconPhosphor } from '@/types'
 
 /**
@@ -373,7 +373,7 @@ const lastRangeRow = computed(() => +pageValue.value * props.perPage)
 const currentPageInput = ref<number>(0)
 const currentRowInput = ref<number>(0)
 
-watch(modelValue, (value) => {
+watch(modelValue, (value: number) => {
   // Update currentPageInput value based on totalRows
   currentPageInput.value = props.totalRows ? +value : 0
   // Determine the row offset based on the perPage value.

--- a/lib/components/PhosphorIcon/PhosphorIcon.vue
+++ b/lib/components/PhosphorIcon/PhosphorIcon.vue
@@ -97,21 +97,22 @@ const currentHover = ref(false)
 watch(() => props.hover, () => (currentHover.value = props.hover), { immediate: true })
 
 const weightComp = computed((): IconWeight => {
+  const weights = ICON_WEIGHT as Record<string, IconWeight>
   if (isArray(props.name) && props.name.length > 1) {
     const weight = props.name[1] as IconWeight
-    return ICON_WEIGHT[weight]
+    return weights[weight]
   }
 
   if (currentHover.value && props.hoverWeight) {
-    return ICON_WEIGHT[props.hoverWeight]
+    return weights[props.hoverWeight]
   }
 
   if (props.fill) {
     return ICON_WEIGHT.fill
   }
 
-  if (ICON_WEIGHT[props.weight]) {
-    return ICON_WEIGHT[props.weight]
+  if (props.weight && weights[props.weight]) {
+    return weights[props.weight]
   }
 
   return ICON_WEIGHT.regular

--- a/lib/components/ResponsiveIframe/ResponsiveIframe.vue
+++ b/lib/components/ResponsiveIframe/ResponsiveIframe.vue
@@ -4,6 +4,12 @@ import type { Parent } from 'pym.js'
 
 import { injectAssets } from '@/utils/assets'
 
+declare global {
+  interface Window {
+    pym: { Parent: new (id: string, url: string, options: object) => Parent }
+  }
+}
+
 defineOptions({
   name: 'ResponsiveIframe'
 })

--- a/lib/components/SharingOptions/SharingOptionsLink.vue
+++ b/lib/components/SharingOptions/SharingOptionsLink.vue
@@ -166,12 +166,14 @@ const icon = computed((): string | null => {
   return get(networks, [props.network, 'icon'], null)
 })
 
-const query = computed((): any => {
+const query = computed((): Record<string, string> => {
+  type PropKey = 'url' | 'title' | 'description' | 'media' | 'user' | 'hashtags'
   return reduce(
     args.value,
-    (obj, prop, param) => {
-      if (props[prop]) {
-        obj[param] = props[prop]
+    (obj: Record<string, string>, prop: string, param: string) => {
+      const value = props[prop as PropKey]
+      if (value) {
+        obj[param] = value
       }
       return obj
     },

--- a/lib/components/SlideUpDown/SlideUpDown.vue
+++ b/lib/components/SlideUpDown/SlideUpDown.vue
@@ -113,7 +113,7 @@ onMounted(async () => {
   await deferredNextTick()
   mounted.value = true
   await cleanLayout(null)
-  container.value?.addEventListener('transitionend', e =>
+  container.value?.addEventListener('transitionend', (e: TransitionEvent) =>
     cleanLayout(e)
   )
 })

--- a/lib/composables/useColorMode.ts
+++ b/lib/composables/useColorMode.ts
@@ -14,7 +14,7 @@ export function useColorMode(element = window?.document?.body, defaultColorMode 
   }
 
   // MutationObserver to watch for changes to the data-bs-theme attribute
-  let observer = null
+  let observer: MutationObserver | null = null
 
   onMounted(() => {
     // Set initial color mode

--- a/lib/composables/useSendEmail.ts
+++ b/lib/composables/useSendEmail.ts
@@ -40,12 +40,12 @@ export function useSendEmail(
     url.searchParams.set('SIGNUP', tracker)
     url.searchParams.set('MMERGE24', parentReferrer.value)
     url.searchParams.set(emailField, emailValue)
-    groups.value.map(group => url.searchParams.set(group, '1'))
+    groups.value.map((group: string) => url.searchParams.set(group, '1'))
 
     return url.href
   })
 
-  function send() {
+  function send(): Promise<FormDataResult> {
     return new Promise((resolve, reject) => {
       jsonp(
         submitUrl.value,

--- a/lib/datavisualisations/BarChart/BarChart.vue
+++ b/lib/datavisualisations/BarChart/BarChart.vue
@@ -108,9 +108,8 @@ const scale = computed(() => {
 })
 
 const bars = computed((): Bar[] => {
-  return sortedData.value.map((d: Datum, i) => {
+  return sortedData.value.map((d: Datum, i: number) => {
     return {
-      // @ts-expect-error D3 api
       width: Math.abs(scale.value.x(d.value)),
       height: Math.abs(props.barHeight),
       value: d.value,
@@ -122,7 +121,7 @@ const bars = computed((): Bar[] => {
 })
 
 const labels = computed(() => {
-  return sortedData.value.map((d: Datum, i) => {
+  return sortedData.value.map((d: Datum, i: number) => {
     return {
       label: d.label,
       x: labelWidth.value,

--- a/lib/datavisualisations/StackedBarChart/StackedBarChart.vue
+++ b/lib/datavisualisations/StackedBarChart/StackedBarChart.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Timeout } from 'node:timers'
 import * as d3 from 'd3'
 import find from 'lodash/find'
 import get from 'lodash/get'
@@ -71,7 +70,7 @@ const emit = defineEmits<{
 }>()
 
 const highlightedKeys = ref(props.highlights)
-const highlightTimeout = ref<Timeout | undefined>(undefined)
+const highlightTimeout = ref<ReturnType<typeof setTimeout> | undefined>(undefined)
 const isLoaded = ref(false)
 const el = ref<ComponentPublicInstance<HTMLElement> | null>(null)
 
@@ -201,11 +200,21 @@ function barStyle(i: number | string, key: string) {
   return { width, backgroundColor }
 }
 
-function stackBarAndValue(i: number | string) {
+interface StackItem {
+  key: string
+  barEdge: number
+  barWidth: number
+  rowEdge: number
+  valueWidth: number
+  overflow: boolean
+  pushed: boolean
+}
+
+function stackBarAndValue(i: number | string): StackItem[] {
   if (!mounted.value) {
     return []
   }
-  const stack = discoveredKeys.value.map((key: string) => {
+  const stack: StackItem[] = discoveredKeys.value.map((key: string) => {
     const { bar, row, value } = queryBarAndValue(i as number, key)
     if (!bar || !row || !value) {
       throw new Error('Values not retrieved')
@@ -284,7 +293,7 @@ function formatXDatum(d: string) {
   return d3Formatter(d, props.xAxisTickFormat)
 }
 
-watch(() => props.highlights, (newHighlights) => {
+watch(() => props.highlights, (newHighlights: any[]) => {
   highlightedKeys.value = newHighlights
 })
 </script>

--- a/lib/datavisualisations/StackedColumnChart/StackedColumnChart.vue
+++ b/lib/datavisualisations/StackedColumnChart/StackedColumnChart.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Timeout } from 'node:timers'
 import * as d3 from 'd3'
 import keysFn from 'lodash/keys'
 import find from 'lodash/find'
@@ -153,7 +152,7 @@ const width = ref(0)
 const height = ref(0)
 const leftAxisHeight = ref(0)
 const highlightedKeys = ref(props.highlights)
-const highlightTimeout = ref<Timeout | undefined>(undefined)
+const highlightTimeout = ref<ReturnType<typeof setTimeout> | undefined>(undefined)
 const isLoaded = ref(false)
 const el = ref<ComponentPublicInstance<HTMLElement> | null>(null)
 const { querySelector, querySelectorAll } = useQueryObserver(el.value)
@@ -331,12 +330,22 @@ function barUniqueId(i: string | number, key: string) {
   return `bar-${uid}-${i}-${key}`
 }
 
-function stackBarAndValue(i: string | number) {
+interface StackItem {
+  key: string
+  barEdge: number
+  barHeight: number
+  rowEdge: number
+  valueHeight: number
+  overflow: boolean
+  pushed: boolean
+}
+
+function stackBarAndValue(i: string | number): StackItem[] {
   if (!sortedData.value) {
     return []
   }
   // Collect sizes first
-  const stack = discoveredKeys.value.map((key: string) => {
+  const stack: StackItem[] = discoveredKeys.value.map((key: string) => {
     const { bar, row, value } = queryBarAndValue(i as number, key)
     if (!bar || !row || !value) {
       throw new Error('Empty values for bar, row or value')
@@ -356,7 +365,7 @@ function stackBarAndValue(i: string | number) {
     }
   })
   // Infer value's display
-  return stack.map((desc, index) => {
+  return stack.map((desc: StackItem, index: number) => {
     desc.overflow = desc.valueHeight >= desc.barHeight
     if (index > 0) {
       const prevDesc = stack[index - 1]
@@ -427,7 +436,7 @@ function formatYDatum(d: string) {
 
 watch(
   () => props.highlights,
-  (newHighlights) => {
+  (newHighlights: any[]) => {
     highlightedKeys.value = newHighlights
   }
 )

--- a/lib/directives/EllipsisTooltip.ts
+++ b/lib/directives/EllipsisTooltip.ts
@@ -1,4 +1,4 @@
-import { type Directive } from 'vue'
+import { type Directive, type DirectiveBinding } from 'vue'
 
 import {
   bind,
@@ -10,7 +10,7 @@ import {
 } from '@/utils/floatingUi'
 
 export default {
-  mounted(el, binding) {
+  mounted(el: ElementWithPopper, binding: DirectiveBinding) {
     const props = resolveDirectiveProps(binding, el)
     const tooltip = resolveActiveStatus(binding.value)
     const text = resolveContent(binding.value, el)
@@ -33,7 +33,7 @@ export default {
     resizeObserver.observe(el)
     toggleTooltip(el)
   },
-  beforeUnmount(el) {
+  beforeUnmount(el: ElementWithPopper) {
     unbind(el)
   }
 } satisfies Directive<ElementWithPopper>

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -161,11 +161,9 @@ const Murmur = {
     return Murmur.i18n.global.mergeLocaleMessage(lang, message)
   },
   setLocale(lang: 'fr' | 'en') {
-    // @ts-expect-error not sure why typescript sees an error here
     return (Murmur.i18n.global.locale.value = lang)
   },
   getLocale() {
-    // @ts-expect-error not sure why typescript sees an error here
     return Murmur.i18n.global.locale.value
   },
   install(app: App<Element>, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icij/murmur-next",
-  "version": "4.5.12",
+  "version": "4.6.0",
   "private": false,
   "description": "Murmur is ICIJ's Design System for Bootstrap 5 and Vue.js",
   "author": "promera@icij.org",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,9 @@ export default defineConfig({
         'vitest.config.ts',
       ],
       outDir: 'dist/lib',
+      tsconfigPath: './tsconfig.json',
+      // Suppress vite-plugin-dts diagnostic output (bogus TS2614 Vue import errors)
+      logLevel: 'silent',
     }),
     VueI18nPlugin({
       /* options */


### PR DESCRIPTION
 Resolves TypeScript errors that appeared during `yarn build:lib` by adding explicit types throughout the codebase and configuring `vite-plugin-dts` to suppress false positive diagnostics.

## Changes

- Configure `vite-plugin-dts` to suppress bogus TS2614 Vue import errors during declaration generation
- Replace node:timers Timeout type with native `ReturnType<typeof setTimeout>`
- Add missing Phosphor icon imports in `PaginationTiny`
- Add explicit types to watch callbacks, directives, and composables
- Add type assertions for dynamic property indexing
- Add `Window.pym` type declaration for `ResponsiveIframe`
- Remove unused @ts-expect-error directives
